### PR TITLE
Fix for projects.json and projectlist.json in docs

### DIFF
--- a/00web/json.xml
+++ b/00web/json.xml
@@ -15,7 +15,7 @@
 
 <esp:sh>Top-level Oracc Data</esp:sh>
 
-<p>Two files are provided at the top level: a simple list of public projects (projects.json) and a complex list of public projects analogous to the one-page listing of projects with blurbs (projectlist.json). In each case, these can be retrieved by prefixing them with an Oracc server name, e.g., http://oracc.org/projects.json or http://oracc.museum.upenn.edu/projects.json.</p>
+<p>Two files are provided at the top level: a simple list of public projects (projects.json) and a complex list of public projects analogous to the one-page listing of projects with blurbs (projectlist.json). In each case, these can be retrieved by prefixing them with an Oracc server name, e.g., http://oracc.org/json/projects.json or http://oracc.museum.upenn.edu/json/projects.json.</p>
 
 <dl>
 <dt>projects.json: type "projects"</dt>


### PR DESCRIPTION
Seems like all the project specific files are down though... [project]/{x}.json returns an empty page, [project]/json/{x}.json just provides a zip file of the entire project.